### PR TITLE
build: support HEAD with multiple tags

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -14,7 +14,7 @@ snapshot=".${date}git${commit}"
 
 # Check if the commit is tagged (indicates a release build):
 tag="$(git tag --points-at ${commit} | grep -v jenkins || true)"
-if [ ! -z ${tag} ]; then
+if [ ! -z "${tag}" ]; then
   snapshot=""
 fi
 


### PR DESCRIPTION
In the case of a HEAD commit having multiple tags, the existing
build script would fail to recognize it as a tagged commit and
build as a snapshot build.  The simple fix to add some quotes fixes
this issue.  Now a commit with any number of tags will produce a
release build.